### PR TITLE
boot: use fpath when upath not provided

### DIFF
--- a/boot.py
+++ b/boot.py
@@ -42,7 +42,7 @@ class BootUSB:
         if upath:
             self.bpath = upath
         else:
-            self.bpath = os.path.join(upath, board)
+            self.bpath = os.path.join(fpath, board)
 
     def wait(self, t):
         print("Waiting...");


### PR DESCRIPTION
If the "board-files" path has not been provided by the user as
arguments, use fpath to generate bpath.

Signed-off-by: Julien Masson <massonju.eseo@gmail.com>