### PR TITLE
Implement bulkcmd, used to send commands to U-Boot

### DIFF
--- a/bulkcmd.py
+++ b/bulkcmd.py
@@ -1,0 +1,13 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+import sys
+
+from pyamlboot import pyamlboot
+
+if __name__ == "__main__":
+    dev = pyamlboot.AmlogicSoC()
+
+    response = dev.bulkCmd(" ".join(sys.argv[1:]))
+
+    print(response.tobytes().decode("utf-8"))


### PR DESCRIPTION
See [here][u-boot-impl] for the gadget-side implementation of this in Amlogic's U-Boot. Even though I don't believe this is implemented in ROMs, it belongs in this tool because the U-Boot implementation speaks basically the same protocol as the ROMs do.

Also add an extremely simple script to send its argument as a command to a connected device.

[u-boot-impl]: https://github.com/khadas/u-boot/blob/4c6694f6a8c250fcf88b4cdd1c76587f2b04d21a/drivers/usb/gadget/v2_burning/v2_usb_tool/usb_pcd.c#L703-L708