### PR TITLE
Add second MIT license text and add SPDX tag in all files

### DIFF
--- a/LICENSE.MIT
+++ b/LICENSE.MIT
@@ -1,0 +1,19 @@
+MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -1,5 +1,7 @@
 # Amlogic Boot USB Protocol
 
+<!--- SPDX-License-Identifier: Apache-2.0 OR MIT -->
+
 ## Descriptor
 
 ```

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+<!--- SPDX-License-Identifier: Apache-2.0 OR MIT -->
+
 # pyamlboot: Amlogic SoC USB Boot utility
 
 The Amlogic SoCs have a USB Boot mode setting itself in USB Gadget mode with a custom protocol.

--- a/boot-dbg.cmd
+++ b/boot-dbg.cmd
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0 OR MIT
 echo ##### USB Boot script !! #####
 setenv bootargs console=ttyAML0,115200 drm.debug=0x3f debug earlycon
 booti 0x8080000 0x13000000 0x8008000

--- a/boot-g12.py
+++ b/boot-g12.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0 OR MIT
 # -*- coding: utf-8 -*-
 
 import argparse

--- a/boot.cmd
+++ b/boot.cmd
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0 OR MIT
 echo ##### USB Boot script !! #####
 setenv bootargs console=ttyAML0,115200 earlycon
 booti 0x8080000 0x13000000 0x8008000

--- a/boot.py
+++ b/boot.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0 OR MIT
 # -*- coding: utf-8 -*-
 
 import argparse

--- a/bulkcmd.py
+++ b/bulkcmd.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0 OR MIT
 # -*- coding: utf-8 -*-
 
 import sys

--- a/chainUboot.py
+++ b/chainUboot.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0 OR MIT
 # -*- coding: utf-8 -*-
 
 #

--- a/pyamlboot/pyamlboot.py
+++ b/pyamlboot/pyamlboot.py
@@ -1,21 +1,9 @@
 # -*- coding: utf-8 -*-
+# SPDX-License-Identifier: Apache-2.0 OR MIT
 """
 Amlogic USB Boot Protocol Library
 
    Copyright 2018 BayLibre SAS
-   Author: Neil Armstrong <narmstrong@baylibre.com>
-
-   Licensed under the Apache License, Version 2.0 (the "License");
-   you may not use this file except in compliance with the License.
-   You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
-   Unless required by applicable law or agreed to in writing, software
-   distributed under the License is distributed on an "AS IS" BASIS,
-   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-   See the License for the specific language governing permissions and
-   limitations under the License.
 
 @author: Neil Armstrong <narmstrong@baylibre.com>
 """

--- a/runKernel.py
+++ b/runKernel.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0 OR MIT
 # -*- coding: utf-8 -*-
 
 #

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+
 [egg_info]
 tag_build = 
 tag_date = 0

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0 OR MIT
 
 import setuptools
 
@@ -12,7 +13,7 @@ setuptools.setup(name="pyamlboot",
     url='https://github.com/superna9999/pyamlboot',
     packages=['pyamlboot'],
     scripts=['boot.py', 'boot-g12.py', 'runKernel.py', 'socid.py'],
-    license="Apache 2.0",
+    license="Apache 2.0 OR MIT",
     install_requires=['pyusb', 'setuptools'],
     package_data = {'pyamlboot': files},
 )

--- a/socid.py
+++ b/socid.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0 OR MIT
 # -*- coding: utf-8 -*-
 
 from pyamlboot import pyamlboot


### PR DESCRIPTION
In order to help pyamlboot beeing used in more projects, I'll propose to add a second license which is more compatible with other licenses like the GPL2 licence.

Note this dual licensing will only be valid when merged in the https://github.com/superna9999/pyamlboot master branch.

The https://github.com/bootlin/snagboot maintainer/developer asked me relicensing, I already provided an older version (https://github.com/superna9999/pyamlboot/tree/v1.0-mit-partial-relicense) with only my authorship with SPDX tag on PROTOCOL.md and pyamlboot/pyamlboot.py, but I think it would be better to have the whole source code and text using this dual license.

Acks needed for relicensing:
- [x] @jeromebrunet 
- [x] @tchebb 
- [x] @JulienMasson 

Would you give your ack for such relicensing ?