### PR TITLE
pyamlboot: wait for device enumeration

### DIFF
--- a/boot-g12.py
+++ b/boot-g12.py
@@ -11,6 +11,13 @@ from pyamlboot import pyamlboot
 def list_boards(p):
     return [ d for d in os.listdir(p) if os.path.isdir(os.path.join(p, d)) and os.path.isfile(os.path.join(p, d, "u-boot.bin")) ]
 
+def parse_wait(value):
+    try:
+        value = float(value)
+    except:
+        value = None
+    return value
+
 def parse_cmdline(fpath):
     boards = list_boards(fpath)
     parser = argparse.ArgumentParser(description="USB boot tool for Amlogic G12 SoCs",
@@ -20,6 +27,8 @@ def parse_cmdline(fpath):
                         help="binary to load or name of board")
     parser.add_argument('--board-name', '-b', dest='bname',  action='store_true',
                         help="main argument becomes the name of the board to load (%s)" % boards)
+    parser.add_argument('--timeout', type=parse_wait, action='store', default=0,
+                        help="Timeout in seconds for device to enumerate")
     args = parser.parse_args()
 
     return args
@@ -38,7 +47,10 @@ if __name__ == '__main__':
     else:
         bpath = args.binary
 
-    dev = pyamlboot.AmlogicSoC()
+    if args.timeout is None or args.timeout > 0:
+        print("Waiting for device to enumerate...")
+
+    dev = pyamlboot.AmlogicSoC(timeout=args.timeout)
 
     socid = dev.identify()
 

--- a/boot.py
+++ b/boot.py
@@ -39,7 +39,10 @@ class BootUSB:
             sys.stderr.write('Unsupported board %s, please fill boot parameters\n' % board)
             sys.exit(1)
 
-        self.dev = pyamlboot.AmlogicSoC()
+        if args.timeout is None or args.timeout > 0:
+            print("Waiting for device to enumerate...")
+
+        self.dev = pyamlboot.AmlogicSoC(timeout=args.timeout)
         self.fpath = fpath
         if upath:
             self.bpath = upath
@@ -98,6 +101,13 @@ class BootUSB:
 def list_boards(p):
     return [ d for d in os.listdir(p) if os.path.isdir(os.path.join(p, d)) and (d in gx_boards or d in axg_boards) ]
 
+def parse_wait(value):
+    try:
+        value = float(value)
+    except:
+        value = None
+    return value
+
 def parse_cmdline(boards):
     parser = argparse.ArgumentParser(description="USB boot tool for Amlogic",
                                      formatter_class=argparse.ArgumentDefaultsHelpFormatter)
@@ -114,6 +124,8 @@ def parse_cmdline(boards):
                         help="dtb file to load")
     parser.add_argument('--ramfs', dest='ramfsfile',  action='store',
                         help="ramfs file to load")
+    parser.add_argument('--timeout', type=parse_wait, action='store', default=0,
+                        help="Timeout in seconds for device to enumerate")
 
     args = parser.parse_args()
 

--- a/pyamlboot/pyamlboot.py
+++ b/pyamlboot/pyamlboot.py
@@ -10,6 +10,7 @@ Amlogic USB Boot Protocol Library
 
 import string
 import os
+import time
 import usb.core
 import usb.util
 from struct import Struct, unpack, pack
@@ -55,12 +56,22 @@ WRITE_MEDIA_CHEKSUM_ALG_CRC32 = 0x00f0
 class AmlogicSoC(object):
     """Represents an Amlogic SoC in USB boot Mode"""
 
-    def __init__(self, idVendor=0x1b8e, idProduct=0xc003, usb_backend=None):
+    def __init__(self, idVendor=0x1b8e, idProduct=0xc003, usb_backend=None, timeout=0):
         """Init with vendor/product IDs"""
 
-        self.dev = usb.core.find(idVendor=idVendor,
-                                 idProduct=idProduct,
-                                 backend=usb_backend)
+        start = time.time()
+        while True:
+            self.dev = usb.core.find(idVendor=idVendor,
+                                    idProduct=idProduct,
+                                    backend=usb_backend)
+
+            if self.dev is not None:
+                break
+
+            if timeout is not None and time.time() > start + timeout:
+                break
+
+            time.sleep(0.1)
 
         if self.dev is None:
             raise ValueError('Device not found')


### PR DESCRIPTION
Introduces an optional wait feature to pyamlboot that waits for devices to enumerate rather than give up immediately if a device is not found.