### PR TITLE
Support secureboot for ADNL protocol

### DIFF
--- a/adnl.py
+++ b/adnl.py
@@ -170,6 +170,15 @@ def get_chipinfo(epout, epin, page, offset=None, nbytes=None):
     return msg[offset : offset + nbytes]
 
 
+def adnl_get_feat(epout, epin):
+    """
+    FEAT is 4 bytes value, residing in 'chipinfo-1'-page. Sometimes FEAT is
+    printed out by bootROM or SPL into UART. This value consists of flags.
+    """
+    feat = get_chipinfo(epout, epin, 1, offset=0x24, nbytes=4)
+    return int.from_bytes(feat, "little")
+
+
 def send_burnsteps(epout, epin, burnstep):
     send_cmd(epout, epin, 'setvar:burnsteps', ADNL_REPLY_DATA)
 

--- a/adnl.py
+++ b/adnl.py
@@ -36,8 +36,13 @@ TPL_BURNSTEPS_1 = 0xC0041031
 TPL_BURNSTEPS_2 = 0xC0041032
 
 ADNL_ROM_STAGE = 0
+ADNL_SPL_STAGE = 8
 ADNL_TPL_STAGE = 16
-
+stages = {
+    ADNL_ROM_STAGE: "BootROM",
+    ADNL_SPL_STAGE: "BL2",
+    ADNL_TPL_STAGE: "U-Boot"
+}
 
 class CBW:
     def __init__(self, msg) -> None:
@@ -263,7 +268,14 @@ def run_bl2_stage(epout, epin, aml_img):
     # and enters USB gadget mode to continue ADNL burning process.
     logging.info('Running BL2 stage...')
 
-    send_cmd_identify(epout, epin)
+    # First, check that we are in SPL stage
+    stage = send_cmd_identify(epout, epin)
+    if stage != ADNL_SPL_STAGE:
+        raise RuntimeError(f'Stage:{stage} ({stages[stage]}). '
+                           'Seems, BL2 has not been booted yet. Probably, '
+                           'you are trying to boot for example the unsigned '
+                           'BL2 on securebooted device. '
+                           'Check your image, please')
 
     logging.info('Send burnsteps after BL2')
     send_burnsteps(epout, epin, BOOTROM_BURNSTEPS_3)

--- a/adnl.py
+++ b/adnl.py
@@ -247,10 +247,14 @@ def run_bootrom_stage(epout, epin, aml_img):
     if strmsg != ADNL_REPLY_OKAY:
         raise RuntimeError('Unexpected reply to "getvar:downloadsize"')
 
-    logging.info('Send download size for BL2')
-    # despite another size of image, send 00010000 as
-    # param - seems ROM code works only with this value.
-    send_cmd(epout, epin, 'download:00010000', ADNL_REPLY_DATA)
+    # Reply is null-terminated
+    bl2_size = int(msg.tobytes().split(b'\x00', 1)[0][4:], 0)
+
+    logging.info('Send download size:0x{:08x} for BL2'.format(bl2_size))
+    # Despite another size of image, send only part of whole image with the
+    # size, extracted by 'downloadsize' cmd - seems ROM code works only with
+    # this value.
+    send_cmd(epout, epin, 'download:{:08x}'.format(bl2_size), ADNL_REPLY_DATA)
 
     logging.info('Sending SPL image...')
     send_cmd(epout, epin, item.read())

--- a/adnl.py
+++ b/adnl.py
@@ -68,6 +68,20 @@ class Stage(IntEnum):
         return super().name
 
 
+class SocFamily(IntEnum):
+    """
+    Map of SoC Family name to numeric ID.
+    """
+    A1 = 0x2c
+    C1 = 0x30
+    SC2 = 0x32
+    C2 = 0x33
+    T5 = 0x34
+    T5D = 0x35
+    T7 = 0x36
+    S4 = 0x37
+
+
 class CBW:
     def __init__(self, msg) -> None:
         magic = msg[4:8].tobytes().decode()
@@ -177,6 +191,14 @@ def adnl_get_feat(epout, epin):
     """
     feat = get_chipinfo(epout, epin, 1, offset=0x24, nbytes=4)
     return int.from_bytes(feat, "little")
+
+
+def adnl_get_soc_family_id(epout, epin):
+    """
+    SoC Family is 4 byte value from 'chipinfo-1'-page.
+    """
+    soc_fid = get_chipinfo(epout, epin, 1, offset=0x4, nbytes=4)
+    return SocFamily(int.from_bytes(soc_fid, "little"))
 
 
 def send_burnsteps(epout, epin, burnstep):

--- a/ubt.py
+++ b/ubt.py
@@ -46,7 +46,7 @@ def main():
     parser.add_argument('--wipe',
                         type=lambda x: WipeFormat[x],
                         choices=list(WipeFormat),
-                        default='no',
+                        default='normal',
                         help='Destroy all partitions')
     parser.add_argument('--password',
                         type=argparse.FileType('rb'),


### PR DESCRIPTION
This patch-set provides secureboot support for ADNL protocol.
For that,
* first of all, some fixes are done into initial ADNL implementation, disclosed during  secureboot bringup
* secondly, useful commands are introduced for working with chipinfo, FEAT, SoC family ID

Finally, secureboot support is provided. This is a "mixed" flavor of secureboot, when BL2, BL31, BL32, etc and Uboot itself are under Amlogic secureboot, but boot.img, dt.img, etc are under Verified boot, for example, under FIT-verification in U-Boot. This approach gives us facility to use community-proven solutions for secureboot stages, starting from U-Boot stage, whereas still using the usual Amlogic's proprietary secureboot approach for closed-source components from boot chain