### PR TITLE
Usb wait optimus run

### DIFF
--- a/optimus.py
+++ b/optimus.py
@@ -288,7 +288,7 @@ class BurnStepDownloadBase(BurnStepBase):
                                    blockLength=len(params))
 
     def _check_para(self, magic):
-        data = self._dev.readLargeMemory(self._platform.bl2ParaAddr, 0x200)
+        data = self._dev.readLargeMemory(self._platform.bl2ParaAddr, 0x200, 0x200)
         para_magic = unpack('<I', data[:4])[0]
         if para_magic != magic:
             raise Exception(f'Fail read para: {para_magic:x}')

--- a/optimus.py
+++ b/optimus.py
@@ -93,15 +93,12 @@ class BurnStepBase:
         while True:
             try:
                 pyamlboot.AmlogicSoC(usb_backend=USB_BACKEND)
-            except Exception:
-                if not for_connect:
-                    break
-
-                if (time.time() - start_time) >= timeout:
-                    raise TimeoutError('Detect Device connect timeout')
-            else:
+            finally:
                 if for_connect:
                     break
+
+            if (time.time() - start_time) >= timeout:
+                raise TimeoutError('Detect Device connect timeout')
 
             time.sleep(0.5)
 
@@ -174,13 +171,10 @@ class BurnStepEraseBootloader(BurnStepBase):
         self._check_bulk_cmd('erase_bootloader')
         try:
             self._check_bulk_cmd('reset')
+            self._dev.disposeDevice()
         except Exception:
             pass
 
-        logging.info('Waiting for connect device after reset...')
-        self._wait_device(True)
-        self._wait_device()
-        logging.info('Device is connected')
         return True
 
 
@@ -513,12 +507,7 @@ class BurnStepDownloadUboot(BurnStepDownloadBase):
         socid = SocId(self._dev.identify())
         self._run()
 
-        self._wait_device(False)
-        self._wait_device()
-        time.sleep(5)
-
-        self._dev = pyamlboot.AmlogicSoC(usb_backend=USB_BACKEND)
-        socid = SocId(self._dev.identify())
+        self._dev.disposeDevice()
         return True
 
 


### PR DESCRIPTION
This patch-set fixes the situation when usb device is enumerated but "Optimus" is not yet ready to respond.
During the burning process the device reboots several times. While it reboots usb enumerates it earlier that the device is ready to respond to commands. We could solve this by timeout, but better way to try wait for responce for identification command.